### PR TITLE
tokenizers are empty for re-index and first initialization

### DIFF
--- a/worker/silversearch.ts
+++ b/worker/silversearch.ts
@@ -30,7 +30,7 @@ async function checkIfInitalized() {
     searchEngine = await SearchEngine.loadFromCache(settings);
 
     if (!searchEngine) {
-        searchEngine = new SearchEngine(settings);
+        searchEngine = await SearchEngine.create(settings);
         await searchEngine.reindex();
     } else if (actionQueue.length) {
         await searchEngine.indexByPaths(actionQueue.filter((action) => action.action === "index").map((action) => action.path));


### PR DESCRIPTION
When cache is empty, `SearchEngine` is created with empty tokenizers. This happens for `reindex` or first initialization.

As tokenizers are part of the index process, when they're available, they should be part of `SearchEngine` creation. 

So I make the constructor private and add an async `create` to handle the initialization of tokenizers and `SearchEngine`